### PR TITLE
docs: add stable agent PR template and open-pr prompt

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,3 +5,12 @@
 - Prefer British English spelling in prose (for example: "synchronise",
   "synchronisation").
 - Keep language simple, direct, and concise.
+
+## Pull request drafting
+
+- When asked to open, prepare, or draft a pull request, always use the template
+  in `.github/prompts/assets/pull-request-template.md`.
+- Keep section headings and order exactly as written in that template.
+- If information is missing, write "N/A" rather than removing sections.
+- This template is for agent output only and is not a mandatory developer
+  template.

--- a/.github/prompts/assets/pull-request-template.md
+++ b/.github/prompts/assets/pull-request-template.md
@@ -1,0 +1,51 @@
+## Summary
+
+<!--
+Explain what changed and why this work is needed.
+Keep this short and easy to scan: 2 to 4 bullets.
+-->
+
+- <change 1>: <reason>
+
+## Context
+
+<!--
+Provide the background needed by reviewers.
+Include constraints, user impact, and non-obvious trade-offs. Write "N/A" if no
+extra context is needed.
+-->
+
+- <context, constraints, or N/A>
+
+## Changes
+
+<!--
+List concrete implementation details.
+Use one bullet per meaningful change. Include links to key files only when
+useful for review.
+-->
+
+- <change 1>
+- <change 2>
+
+## Risks and mitigations
+
+<!--
+Describe realistic risks (behavioural, performance, migration, UX).
+For each risk, add the mitigation or why risk is acceptable.
+Write "N/A" if no material risk was introduced.
+-->
+
+- <risk>: <mitigation>
+
+## Checklist
+
+<!--
+Tick every item before opening or merging the pull request.
+Leave an item unticked only when not applicable and explain why in the PR.
+-->
+
+- [ ] Added in-code documentation (wherever needed).
+- [ ] Ran the linter to ensure style guidelines were followed.
+- [ ] Reviewed the changes for regressions.
+- [ ] Manually tested the changed behaviour.

--- a/.github/prompts/open-pr.prompt.md
+++ b/.github/prompts/open-pr.prompt.md
@@ -1,0 +1,48 @@
+---
+name: open-pr
+description: Open a pull request using the stable agent template
+agent: agent
+model: GPT-5.3-Codex
+tools:
+  - execute/runInTerminal
+argument-hint: Optional mode, use `draft` to open a draft pull request
+---
+
+Open a pull request from the current branch changes.
+
+Input:
+
+- ${input:mode:Optional mode. Use `draft` for a draft pull request}
+
+Workflow:
+
+1. Collect context from git:
+   - Branch name.
+   - Commits ahead of `dev`.
+   - Changed files.
+2. Set base branch to `dev`.
+3. Summarise what changed, why, context, risks, and manual testing evidence.
+4. Produce a pull request body using this exact template and section order:
+   `.github/prompts/assets/pull-request-template.md`
+5. If any section details are unknown, write "N/A".
+6. Do not remove sections.
+7. Ensure the branch is pushed to origin.
+8. Decide draft mode from input:
+   - If `mode` is `draft`, create a draft pull request.
+   - If `mode` is missing or any other value, create a ready-for-review pull
+     request.
+9. Open the pull request with GitHub CLI using the generated title and body.
+10. Return only the created pull request URL.
+
+Command requirements:
+
+1. Verify `gh` is installed and authenticated before creating the pull request.
+2. Create the pull request using `gh pr create` with explicit title and body.
+3. Always use `--base dev`.
+4. Use `--draft` only when `mode` is `draft`.
+
+Output format:
+
+```md
+PR URL: <created pull request URL>
+```


### PR DESCRIPTION
## Summary

- Added repository-level Copilot instructions to enforce a stable pull request template for agent-authored PRs.
- Added a reusable pull request template asset with guidance comments and a precise checklist.
- Added an `open-pr` prompt that gathers git context and opens PRs through `gh` with optional draft mode.

## Context

- This standardises agent-generated pull request content while keeping developer PR formatting optional.
- The prompt is configured for the repository workflow with `dev` as the base branch.
- Manual testing evidence: reviewed prompt and template output paths and validated CLI authentication flow for PR creation.

## Changes

- Updated `.github/copilot-instructions.md` with pull request drafting rules that point to the stable template asset.
- Added `.github/prompts/assets/pull-request-template.md` with open-source-style sections and checklist guidance.
- Added `.github/prompts/open-pr.prompt.md` to generate template-based PR bodies and open PRs via GitHub CLI.

## Risks and mitigations

- Process risk: the prompt could drift from team expectations over time: mitigated by centralising template guidance in the asset and instruction file.
- Tooling risk: PR creation depends on local `gh` authentication: mitigated by explicit auth checks in the prompt workflow.

## Checklist

- [x] Added in-code documentation (wherever needed).
- [ ] Ran the linter to ensure style guidelines were followed.
- [x] Reviewed the changes for regressions.
- [x] Manually tested the changed behaviour.
