### PR TITLE
feat(show): Add ids to landing page sections

### DIFF
--- a/apps/show/src/routes/_layout._index/route-online.tsx
+++ b/apps/show/src/routes/_layout._index/route-online.tsx
@@ -38,7 +38,7 @@ export function RouteOnline() {
 
 function SectionHero() {
   return (
-    <Section.Root columnCount={1}>
+    <Section.Root id="accueil" columnCount={1}>
       <div className="grid grid-cols-1 gap-2 sm:gap-0 md:grid-cols-auto-fr md:items-start">
         <LazyElement asChild>
           <div
@@ -160,7 +160,7 @@ function CountDownItem({ label, value }: { label: string; value: number }) {
 
 function SectionComeWithYourDog() {
   return (
-    <Section.Root>
+    <Section.Root id="venir-avec-son-chien">
       <LazyElement asChild>
         <Section.ImageAside
           className={cn(
@@ -208,7 +208,7 @@ function SectionPresentation() {
   const { exhibitorCount } = useLoaderData<typeof loader>()
 
   return (
-    <Section.Root width="full" columnCount={1}>
+    <Section.Root id="presentation" width="full" columnCount={1}>
       <div className="grid grid-cols-1 gap-4">
         <section className="grid grid-cols-1 gap-2 px-safe-page-narrow sm:gap-4 md:grid-cols-2 md:items-center md:px-safe-page-normal lg:gap-8">
           <LazyElement asChild>
@@ -298,7 +298,7 @@ function PresentationItem({
 
 function SectionOrigin() {
   return (
-    <Section.Root columnCount={1}>
+    <Section.Root id="origine" columnCount={1}>
       <LazyElement asChild>
         <Section.TextAside asChild>
           <BoardCard className="animation-duration-very-slow out-opacity-0 out-translate-y-4 data-visible:animate-enter data-hidden:opacity-0">
@@ -340,7 +340,7 @@ function SectionSponsors() {
   const { sponsors } = useLoaderData<typeof loader>()
 
   return (
-    <Section.Root width="full" columnCount={1}>
+    <Section.Root id="sponsors" width="full" columnCount={1}>
       <LazyElement asChild>
         <Section.TextAside
           className={cn(
@@ -396,7 +396,7 @@ function SectionExhibitors() {
   const { exhibitorCount } = useLoaderData<typeof loader>()
 
   return (
-    <Section.Root>
+    <Section.Root id="exposants">
       <LazyElement asChild>
         <Section.ImageAside
           className={cn(
@@ -471,6 +471,7 @@ function ExhibitorItem({
 function SectionPreviousEditions() {
   return (
     <Section.Root
+      id="editions-precedentes"
       width="full"
       height="large"
       columnCount={1}
@@ -543,7 +544,7 @@ function SectionPreviousEditions() {
 
 function SectionAccess() {
   return (
-    <Section.Root>
+    <Section.Root id="acces">
       <LazyElement asChild>
         <Section.ImageAside
           className={cn(
@@ -590,7 +591,7 @@ function SectionProviders() {
   const { providers } = useLoaderData<typeof loader>()
 
   return (
-    <Section.Root width="full" columnCount={1}>
+    <Section.Root id="prestataires" width="full" columnCount={1}>
       <LazyElement asChild>
         <Section.TextAside
           className={cn(

--- a/apps/show/src/routes/_layout._index/route-waiting.tsx
+++ b/apps/show/src/routes/_layout._index/route-waiting.tsx
@@ -24,7 +24,10 @@ export function RouteWaiting() {
 
 function SectionLogo() {
   return (
-    <header className="grid grid-cols-1 justify-items-center pt-safe-4 px-safe-page-narrow pb-4 md:px-safe-page-normal">
+    <header
+      id="accueil"
+      className="grid grid-cols-1 justify-items-center pt-safe-4 px-safe-page-narrow pb-4 md:px-safe-page-normal"
+    >
       <img
         src={logoLarge}
         alt="Salon des Ani’Meaux"
@@ -36,7 +39,7 @@ function SectionLogo() {
 
 function SectionComeBack() {
   return (
-    <Section.Root>
+    <Section.Root id="retour-en-2026">
       <LazyElement asChild>
         <Section.ImageAside
           className={cn(
@@ -87,6 +90,7 @@ function SectionComeBack() {
 function SectionPreviousEditions() {
   return (
     <Section.Root
+      id="editions-precedentes"
       width="full"
       height="large"
       columnCount={1}
@@ -159,7 +163,7 @@ function SectionPreviousEditions() {
 
 function SectionFollow() {
   return (
-    <Section.Root width="full" columnCount={1}>
+    <Section.Root id="nous-suivre" width="full" columnCount={1}>
       <LazyElement asChild>
         <Section.TextAside
           className={cn(

--- a/apps/show/src/routes/_layout.acces/section-carpool.tsx
+++ b/apps/show/src/routes/_layout.acces/section-carpool.tsx
@@ -8,7 +8,7 @@ import { Section } from "#i/core/layout/section.js"
 
 export function SectionCarpool() {
   return (
-    <Section.Root>
+    <Section.Root id="covoiturage">
       <LazyElement asChild>
         <Section.ImageAside
           className={cn(

--- a/apps/show/src/routes/_layout.acces/section-ecology.tsx
+++ b/apps/show/src/routes/_layout.acces/section-ecology.tsx
@@ -4,7 +4,7 @@ import { Section } from "#i/core/layout/section.js"
 
 export function SectionEcology() {
   return (
-    <Section.Root columnCount={1}>
+    <Section.Root id="transports-ecologiques" columnCount={1}>
       <LazyElement asChild>
         <Section.TextAside asChild>
           <BoardCard className="animation-duration-very-slow out-opacity-0 out-translate-y-4 data-visible:animate-enter data-hidden:opacity-0">

--- a/apps/show/src/routes/_layout.acces/section-information.tsx
+++ b/apps/show/src/routes/_layout.acces/section-information.tsx
@@ -7,6 +7,7 @@ export function SectionInformation() {
   return (
     <LazyElement asChild>
       <Section.Root
+        id="informations"
         columnCount={1}
         width="full"
         className="animation-duration-very-slow out-opacity-0 out-translate-y-4 data-visible:animate-enter data-hidden:opacity-0"

--- a/apps/show/src/routes/_layout.acces/section-title.tsx
+++ b/apps/show/src/routes/_layout.acces/section-title.tsx
@@ -8,7 +8,7 @@ import { Section } from "#i/core/layout/section.js"
 
 export function SectionTitle() {
   return (
-    <Section.Root>
+    <Section.Root id="acces-au-salon">
       <LazyElement asChild>
         <Section.ImageAside
           className={cn(

--- a/apps/show/src/routes/_layout.faq/section-more-questions.tsx
+++ b/apps/show/src/routes/_layout.faq/section-more-questions.tsx
@@ -5,7 +5,7 @@ import { Section } from "#i/core/layout/section.js"
 
 export function SectionMoreQuestions() {
   return (
-    <Section.Root columnCount={1}>
+    <Section.Root id="autre-question" columnCount={1}>
       <LazyElement asChild>
         <Section.TextAside asChild>
           <LightBoardCard className="animation-duration-very-slow out-opacity-0 out-translate-y-4 data-visible:animate-enter data-hidden:opacity-0">

--- a/apps/show/src/routes/_layout.faq/section-questions.tsx
+++ b/apps/show/src/routes/_layout.faq/section-questions.tsx
@@ -9,7 +9,7 @@ export function SectionQuestions() {
   const { questions } = useLoaderData<typeof loader>()
 
   return (
-    <Section.Root columnCount={1}>
+    <Section.Root id="questions" columnCount={1}>
       <FaqList>
         {questions.map((question) => (
           <FaqItem key={question.question} faq={question} />

--- a/apps/show/src/routes/_layout.faq/section-title.tsx
+++ b/apps/show/src/routes/_layout.faq/section-title.tsx
@@ -6,7 +6,7 @@ import { Section } from "#i/core/layout/section.js"
 
 export function SectionTitle() {
   return (
-    <Section.Root>
+    <Section.Root id="foire-aux-questions">
       <LazyElement asChild>
         <Section.ImageAside
           className={cn(


### PR DESCRIPTION
## Summary

- Add French-language `id` attributes to every section on the home, accès, and FAQ pages: allows linking directly to a section via URL hash (e.g. `/#exposants`, `/acces#covoiturage`).

## Context

- No clickable anchors are exposed to users; the ids are purely for direct URL hash navigation.

## Changes

- `route-online.tsx`: added ids `accueil`, `venir-avec-son-chien`, `presentation`, `origine`, `sponsors`, `exposants`, `editions-precedentes`, `acces`, `prestataires` to each `Section.Root`.
- `route-waiting.tsx`: added ids `accueil`, `retour-en-2026`, `editions-precedentes`, `nous-suivre`.
- `_layout.acces`: added ids `acces-au-salon`, `transports-ecologiques`, `covoiturage`, `informations`.
- `_layout.faq`: added ids `foire-aux-questions`, `questions`, `autre-question`.

## Risks and mitigations

- N/A: adding `id` attributes is purely additive and has no behavioural or visual impact.

## Checklist

- [ ] Added in-code documentation (wherever needed).
- [ ] Ran the linter to ensure style guidelines were followed.
- [x] Reviewed the changes for regressions.
- [ ] Manually tested the changed behaviour.